### PR TITLE
src: add mvn-build-cache option to also cache `~/.m2/build-cache`

### DIFF
--- a/.github/workflows/bump-cache-version.yml
+++ b/.github/workflows/bump-cache-version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       cache_version:
-        description: "New @useblacksmith/cache version"
+        description: 'New @useblacksmith/cache version'
         required: true
         type: string
 
@@ -26,7 +26,7 @@ jobs:
           branch_name="bump-cache-version-${{ github.event.inputs.cache_version }}-$timestamp"
           git checkout -b $branch_name
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
-    
+
       - name: Update package.json
         run: |
           sed -i 's/"@actions\/cache": "npm:@useblacksmith\/cache@[^"]*"/"@actions\/cache": "npm:@useblacksmith\/cache@${{ github.event.inputs.cache_version }}"/' package.json

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,10 @@ inputs:
   mvn-toolchain-vendor:
     description: 'Name of Maven Toolchain Vendor if the default name of "${distribution}" is not wanted. See examples of supported syntax in Advanced Usage file'
     required: false
+  mvn-build-cache:
+    description: 'Include Maven build cache (~/.m2/build-cache) in cached paths. Only valid if "cache" input is set to "maven".'
+    required: false
+    default: 'false'
 outputs:
   distribution:
     description: 'Distribution of Java that has been installed'

--- a/dist/cleanup/index.js
+++ b/dist/cleanup/index.js
@@ -90512,7 +90512,18 @@ const CACHE_KEY_PREFIX = 'setup-java';
 const supportedPackageManager = [
     {
         id: 'maven',
-        path: [(0, path_1.join)(os_1.default.homedir(), '.m2', 'repository')],
+        path: [
+            (0, path_1.join)(os_1.default.homedir(), '.m2', 'repository'),
+            // Add build-cache directory if enabled and exists
+            ...(() => {
+                const shouldCacheBuildCache = core.getInput('mvn-build-cache') === 'true';
+                if (!shouldCacheBuildCache) {
+                    return [];
+                }
+                const buildCachePath = (0, path_1.join)(os_1.default.homedir(), '.m2', 'build-cache');
+                return [buildCachePath];
+            })()
+        ],
         // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---maven
         pattern: ['**/pom.xml']
     },
@@ -90594,6 +90605,7 @@ function restore(id, cacheDependencyPath) {
         core.debug(`primary key is ${primaryKey}`);
         core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
         // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
+        core.info(`Restoring cache for paths: ${packageManager.path.join(', ')}`);
         const matchedKey = yield cache.restoreCache(packageManager.path, primaryKey);
         if (matchedKey) {
             core.saveState(CACHE_MATCHED_KEY, matchedKey);
@@ -90627,6 +90639,7 @@ function save(id) {
             return;
         }
         try {
+            core.info(`Saving cache for paths: ${packageManager.path.join(', ')}`);
             yield cache.saveCache(packageManager.path, primaryKey);
             core.info(`Cache saved with the key: ${primaryKey}`);
         }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -125761,7 +125761,18 @@ const CACHE_KEY_PREFIX = 'setup-java';
 const supportedPackageManager = [
     {
         id: 'maven',
-        path: [(0, path_1.join)(os_1.default.homedir(), '.m2', 'repository')],
+        path: [
+            (0, path_1.join)(os_1.default.homedir(), '.m2', 'repository'),
+            // Add build-cache directory if enabled and exists
+            ...(() => {
+                const shouldCacheBuildCache = core.getInput('mvn-build-cache') === 'true';
+                if (!shouldCacheBuildCache) {
+                    return [];
+                }
+                const buildCachePath = (0, path_1.join)(os_1.default.homedir(), '.m2', 'build-cache');
+                return [buildCachePath];
+            })()
+        ],
         // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---maven
         pattern: ['**/pom.xml']
     },
@@ -125843,6 +125854,7 @@ function restore(id, cacheDependencyPath) {
         core.debug(`primary key is ${primaryKey}`);
         core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
         // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
+        core.info(`Restoring cache for paths: ${packageManager.path.join(', ')}`);
         const matchedKey = yield cache.restoreCache(packageManager.path, primaryKey);
         if (matchedKey) {
             core.saveState(CACHE_MATCHED_KEY, matchedKey);
@@ -125876,6 +125888,7 @@ function save(id) {
             return;
         }
         try {
+            core.info(`Saving cache for paths: ${packageManager.path.join(', ')}`);
             yield cache.saveCache(packageManager.path, primaryKey);
             core.info(`Cache saved with the key: ${primaryKey}`);
         }
@@ -128042,6 +128055,10 @@ function run() {
             core.info(`##[add-matcher]${path.join(matchersPath, 'java.json')}`);
             yield auth.configureAuthentication();
             if (cache && (0, util_1.isCacheFeatureAvailable)()) {
+                const mvnBuildCache = core.getInput('mvn-build-cache');
+                if (mvnBuildCache === 'true' && cache !== 'maven') {
+                    throw new Error('input error: mvn-build-cache can only be used when cache is set to "maven".');
+                }
                 yield (0, cache_1.restore)(cache, cacheDependencyPath);
             }
         }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -7,6 +7,7 @@ import os from 'os';
 import * as cache from '@actions/cache';
 import * as core from '@actions/core';
 import * as glob from '@actions/glob';
+import fs from 'fs';
 
 const STATE_CACHE_PRIMARY_KEY = 'cache-primary-key';
 const CACHE_MATCHED_KEY = 'cache-matched-key';
@@ -23,7 +24,19 @@ interface PackageManager {
 const supportedPackageManager: PackageManager[] = [
   {
     id: 'maven',
-    path: [join(os.homedir(), '.m2', 'repository')],
+    path: [
+      join(os.homedir(), '.m2', 'repository'),
+      // Add build-cache directory if enabled and exists
+      ...(() => {
+        const shouldCacheBuildCache =
+          core.getInput('mvn-build-cache') === 'true';
+        if (!shouldCacheBuildCache) {
+          return [];
+        }
+        const buildCachePath = join(os.homedir(), '.m2', 'build-cache');
+        return [buildCachePath];
+      })()
+    ],
     // https://github.com/actions/cache/blob/0638051e9af2c23d10bb70fa9beffcad6cff9ce3/examples.md#java---maven
     pattern: ['**/pom.xml']
   },
@@ -113,6 +126,7 @@ export async function restore(id: string, cacheDependencyPath: string) {
   core.saveState(STATE_CACHE_PRIMARY_KEY, primaryKey);
 
   // No "restoreKeys" is set, to start with a clear cache after dependency update (see https://github.com/actions/setup-java/issues/269)
+  core.info(`Restoring cache for paths: ${packageManager.path.join(', ')}`);
   const matchedKey = await cache.restoreCache(packageManager.path, primaryKey);
   if (matchedKey) {
     core.saveState(CACHE_MATCHED_KEY, matchedKey);
@@ -146,6 +160,7 @@ export async function save(id: string) {
     return;
   }
   try {
+    core.info(`Saving cache for paths: ${packageManager.path.join(', ')}`);
     await cache.saveCache(packageManager.path, primaryKey);
     core.info(`Cache saved with the key: ${primaryKey}`);
   } catch (error) {

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -76,6 +76,12 @@ async function run() {
 
     await auth.configureAuthentication();
     if (cache && isCacheFeatureAvailable()) {
+      const mvnBuildCache = core.getInput('mvn-build-cache');
+      if (mvnBuildCache === 'true' && cache !== 'maven') {
+        throw new Error(
+          'input error: mvn-build-cache can only be used when cache is set to "maven".'
+        );
+      }
       await restore(cache, cacheDependencyPath);
     }
   } catch (error) {


### PR DESCRIPTION
This change adds an opt-in flag `mvn-build-cache` that will also cache the `~/.m2/build-cache` directory for maven builds. This is in addition to the already cached `~/.m2/repostory` cache.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `mvn-build-cache` option to cache `~/.m2/build-cache` for Maven builds, with input validation and path updates.
> 
>   - **Behavior**:
>     - Adds `mvn-build-cache` input in `action.yml` to optionally cache `~/.m2/build-cache`.
>     - Validates `mvn-build-cache` input in `run()` in `setup-java.ts` to ensure it's only used with Maven.
>     - Updates `restore()` and `save()` in `cache.ts` to include `~/.m2/build-cache` if `mvn-build-cache` is true.
>   - **Misc**:
>     - Minor formatting changes in `bump-cache-version.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fsetup-java&utm_source=github&utm_medium=referral)<sup> for c3e5f5919d89a948341127001776414b11eab472. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->