### PR TITLE
src: add more logging towards the end of the action

### DIFF
--- a/.github/workflows/bump-cache-version.yml
+++ b/.github/workflows/bump-cache-version.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       cache_version:
-        description: "New @useblacksmith/cache version"
+        description: 'New @useblacksmith/cache version'
         required: true
         type: string
 
@@ -26,7 +26,7 @@ jobs:
           branch_name="bump-cache-version-${{ github.event.inputs.cache_version }}-$timestamp"
           git checkout -b $branch_name
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
-    
+
       - name: Update package.json
         run: |
           sed -i 's/"@actions\/cache": "npm:@useblacksmith\/cache@[^"]*"/"@actions\/cache": "npm:@useblacksmith\/cache@${{ github.event.inputs.cache_version }}"/' package.json

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -125645,7 +125645,9 @@ function createAuthenticationSettings(id, username, password, settingsDirectory,
         // when an alternate m2 location is specified use only that location (no .m2 directory)
         // otherwise use the home/.m2/ path
         yield io.mkdirP(settingsDirectory);
+        core.info(`Created settings directory: ${settingsDirectory}`);
         yield write(settingsDirectory, generate(id, username, password, gpgPassphrase), overwriteSettings);
+        core.info(`Wrote ${constants.MVN_SETTINGS_FILE} to ${settingsDirectory}`);
     });
 }
 exports.createAuthenticationSettings = createAuthenticationSettings;
@@ -128042,6 +128044,7 @@ function run() {
             core.info(`##[add-matcher]${path.join(matchersPath, 'java.json')}`);
             yield auth.configureAuthentication();
             if (cache && (0, util_1.isCacheFeatureAvailable)()) {
+                core.info('Cache is enabled; restoring');
                 yield (0, cache_1.restore)(cache, cacheDependencyPath);
             }
         }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -60,11 +60,13 @@ export async function createAuthenticationSettings(
   // when an alternate m2 location is specified use only that location (no .m2 directory)
   // otherwise use the home/.m2/ path
   await io.mkdirP(settingsDirectory);
+  core.info(`Created settings directory: ${settingsDirectory}`);
   await write(
     settingsDirectory,
     generate(id, username, password, gpgPassphrase),
     overwriteSettings
   );
+  core.info(`Wrote ${constants.MVN_SETTINGS_FILE} to ${settingsDirectory}`);
 }
 
 // only exported for testing purposes

--- a/src/setup-java.ts
+++ b/src/setup-java.ts
@@ -76,6 +76,7 @@ async function run() {
 
     await auth.configureAuthentication();
     if (cache && isCacheFeatureAvailable()) {
+      core.info('Cache is enabled; restoring');
       await restore(cache, cacheDependencyPath);
     }
   } catch (error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add logging for directory creation and cache restoration in `src/auth.ts` and `src/setup-java.ts`, with minor formatting changes in workflow file.
> 
>   - **Logging Enhancements**:
>     - In `src/auth.ts`, added logs for directory creation and settings file writing in `createAuthenticationSettings()`.
>     - In `src/setup-java.ts`, added log for cache restoration in `run()`.
>   - **Miscellaneous**:
>     - Minor formatting change in `.github/workflows/bump-cache-version.yml` (whitespace adjustment).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fsetup-java&utm_source=github&utm_medium=referral)<sup> for 5fa8ac86e0789fe1c9c6d62f02a6c3657ae6b47f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->